### PR TITLE
DL-7796 bootstrap-play and play 2.8.15 upgrades

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.4.9","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/Users/iykeuwajeh/Library/Application Support/JetBrains/IntelliJIdea2020.2/plugins/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ dist
 .metals
 project/.bloop
 project/metals.sbt
+.bsp
     

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,9 +19,8 @@ private object AppDependencies {
     def apply() = new TestDependencies {
       override lazy val test: Seq[ModuleID] = Seq(
         "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"             % scope,
-        "org.pegdown"                  %  "pegdown"                % "1.6.0"             % scope,
         "com.typesafe.play"            %% "play-test"              % PlayVersion.current % scope,
-        "org.mockito"                  %  "mockito-core"           % "4.5.1"             % scope,
+        "org.mockito"                  %  "mockito-core"           % "4.6.0"             % scope,
         "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.33.2"            % scope,
         "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.3"            % scope,
         "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % "5.24.0"            % scope

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,8 +6,8 @@ private object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.18.0",
-    "uk.gov.hmrc" %% "domain"                    % "6.2.0-play-28"
+    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.24.0",
+    "uk.gov.hmrc" %% "domain"                    % "8.1.0-play-28"
   )
 
   trait TestDependencies {
@@ -21,10 +21,10 @@ private object AppDependencies {
         "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"             % scope,
         "org.pegdown"                  %  "pegdown"                % "1.6.0"             % scope,
         "com.typesafe.play"            %% "play-test"              % PlayVersion.current % scope,
-        "org.mockito"                  %  "mockito-core"           % "4.2.0"             % scope,
-        "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.32.0"            % scope,
-        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.1"            % scope,
-        "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % "5.18.0"            % scope
+        "org.mockito"                  %  "mockito-core"           % "4.5.1"             % scope,
+        "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.33.2"            % scope,
+        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.3"            % scope,
+        "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % "5.24.0"            % scope
       )
     }.test
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,8 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.2")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
DL-7796 bootstrap-play and play 2.8.15 upgrades

**New feature** 

Upgrade to use bootstrap-play 5.24.0  and play 2.8.15 . This is to protect against a security vulnerability that has been found in Play, and comes of the back of this [techspace blog](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=447906456).

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
